### PR TITLE
Fix bug that was incorrectly displaying the campus map link when no p…

### DIFF
--- a/_includes/javascript/templates.js
+++ b/_includes/javascript/templates.js
@@ -69,7 +69,7 @@ function getAdditionalInfo( space ) {
     if ( space.url !== "" && space.url_text !== '' ) {
         spaceHTML += '<li class="icon-link"><a target="spaceurl" href="' + space.url + '">' + space.url_text + '</a></li>';
     }
-    if ( space.campusmap_url != '' ) {
+    if ( space.campusmap_url !== undefined && space.campusmap_url !== '') {
         let campusmap_ref = space.campusmap_ref !== '' ? ' (map reference ' + space.campusmap_ref + ')': '';
         spaceHTML += '<li class="icon-uol-logo-mark"><a target="campusmap" href="' + space.campusmap_url + '">View on the University campus map</a>' + campusmap_ref + '<li>';
     }


### PR DESCRIPTION
…roperty was set

There is a bug where it will still display the canvas map text and broken link when there is no variable set for a Space. This just adds a check that it's defined before display.